### PR TITLE
Overwrite existing outputs

### DIFF
--- a/cleaner.py
+++ b/cleaner.py
@@ -100,10 +100,10 @@ def procesar_archivos():
     for src in ORIG_DIR.glob("*.xlsx"):
         base_alias = src.stem.split("_")[0].lower()
         dest = CLEAN_DIR / f"{base_alias}_limpia.xlsx"
-        if dest.exists() and dest.stat().st_mtime >= src.stat().st_mtime:
-            print(f"↻  Ya limpio: {dest.name}")
-            continue
-        print(f"→ Procesando {src.name} (base={base_alias})")
+        if dest.exists():
+            print(f"↻  Reemplazando {dest.name}")
+        else:
+            print(f"→ Procesando {src.name} (base={base_alias})")
         xls = pd.ExcelFile(src)
         with pd.ExcelWriter(dest, engine="openpyxl") as xlw:
             hojas_guardadas = 0

--- a/unify_panel.py
+++ b/unify_panel.py
@@ -62,6 +62,8 @@ def construir_panel():
         return
     panel = panel.sort_values(ID_VARS).reset_index(drop=True)
     PANEL_FILE.parent.mkdir(parents=True, exist_ok=True)
+    if PANEL_FILE.exists():
+        print(f"↻  Reemplazando {PANEL_FILE.name}")
     panel.to_excel(PANEL_FILE, index=False)
     print("✅ Panel construido y guardado en:", PANEL_FILE)
 


### PR DESCRIPTION
## Summary
- replace the cleaned files whenever they already exist
- notify when overwriting the unified panel output

## Testing
- `python3 -m py_compile cleaner.py unify_panel.py`


------
https://chatgpt.com/codex/tasks/task_e_6849dcebcffc8333963f955ef3d78291