### PR TITLE
Sort quarters numerically

### DIFF
--- a/unify_panel.py
+++ b/unify_panel.py
@@ -61,7 +61,14 @@ def construir_panel():
     if panel is None:
         print("No se encontraron archivos limpios")
         return
-    panel = panel.sort_values(ID_VARS).reset_index(drop=True)
+    panel["Trimestre_num"] = panel["Trimestre"].map(TRIM_MAP)
+    panel = (
+        panel.sort_values(
+            ["Año", "Trimestre_num", "region_code", "region_name"]
+        )
+        .drop(columns="Trimestre_num")
+        .reset_index(drop=True)
+    )
     panel["Periodo"] = pd.PeriodIndex(
         year=panel["Año"],
         quarter=panel["Trimestre"].map(TRIM_MAP),


### PR DESCRIPTION
## Summary
- ensure panel sorting uses TRIM_MAP to order quarters correctly

## Testing
- `python unify_panel.py` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b306b53ac8333b698dd1504bee671